### PR TITLE
Fixed bug on property setter when there is an enum

### DIFF
--- a/jsonschema2popo/_class.tmpl
+++ b/jsonschema2popo/_class.tmpl
@@ -42,7 +42,7 @@ class {{model.name}}:
 {% endif %}
 {% if prop._enum %}
         if value in self._{{prop._name}}_enum.__members__:
-            self.__type = value
+            self.__{{prop._name}} = value
         else:
             raise ValueError("Value {} not in _{{prop._name}}_enum list".format(value))
 {% else %}


### PR DESCRIPTION
In the class template _class.tmpl, in the setter of the property of a class, in case there is an enum, the value is set on  self.__type. It should be on self.__{{prop._name}} 