### PR TITLE
Respect the order of the definitions in class __init__ parameters

### DIFF
--- a/jsonschema2popo/jsonschema2popo.py
+++ b/jsonschema2popo/jsonschema2popo.py
@@ -4,6 +4,7 @@ import os
 import argparse
 import json
 import networkx
+from collections import OrderedDict
 from jinja2 import Environment, FileSystemLoader
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -29,7 +30,7 @@ class JsonSchema2Popo:
         self.definitions = []
 
     def load(self, json_schema_file):
-        self.process(json.load(json_schema_file))
+        self.process(json.load(json_schema_file, object_pairs_hook=OrderedDict))
 
     def get_model_depencencies(self, model):
         deps = set()


### PR DESCRIPTION
This proposed change will make sure that the parameters of the \_\_init__ of a class respects the order of the definitions in the schema.