### PR TITLE
Fix no property case

### DIFF
--- a/jsonschema2popo/_class.tmpl
+++ b/jsonschema2popo/_class.tmpl
@@ -26,6 +26,8 @@ class {{model.name}}:
             ):
 {% for prop in model.properties %}
         self.__{{prop._name}} = {{prop._name}}
+{% else %}
+        pass
 {% endfor %}
     
 {% for prop in model.properties %}

--- a/jsonschema2popo/_class.tmpl
+++ b/jsonschema2popo/_class.tmpl
@@ -42,7 +42,7 @@ class {{model.name}}:
 {% endif %}
 {% if prop._enum %}
         if value in self._{{prop._name}}_enum.__members__:
-            self.__type = value
+            self.__{{prop._name}} = value
         else:
             raise ValueError("Value {} not in _{{prop._name}}_enum list".format(value))
 {% else %}

--- a/jsonschema2popo/jsonschema2popo.py
+++ b/jsonschema2popo/jsonschema2popo.py
@@ -4,6 +4,7 @@ import os
 import argparse
 import json
 import networkx
+from collections import OrderedDict
 from jinja2 import Environment, FileSystemLoader
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -47,7 +48,7 @@ class JsonSchema2Popo:
         
         # topological oderd dependencies
         g = networkx.DiGraph()
-        models_map = {}
+        models_map = OrderedDict()
         for model in self.definitions:
             models_map[model['name']] = model
             deps = self.get_model_depencencies(model)
@@ -57,7 +58,7 @@ class JsonSchema2Popo:
                 g.add_edge(model['name'], dep)
         
         self.definitions = []
-        for model_name in networkx.topological_sort(g, reverse=True):
+        for model_name in networkx.topological_sort(g, nbunch=models_map.keys(), reverse=True):
             if model_name in models_map:
                 self.definitions.append(models_map[model_name])
         

--- a/jsonschema2popo/jsonschema2popo.py
+++ b/jsonschema2popo/jsonschema2popo.py
@@ -4,6 +4,7 @@ import os
 import argparse
 import json
 import networkx
+from collections import OrderedDict
 from jinja2 import Environment, FileSystemLoader
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -29,7 +30,7 @@ class JsonSchema2Popo:
         self.definitions = []
 
     def load(self, json_schema_file):
-        self.process(json.load(json_schema_file))
+        self.process(json.load(json_schema_file, object_pairs_hook=OrderedDict))
 
     def get_model_depencencies(self, model):
         deps = set()


### PR DESCRIPTION
When an object has no property, the produced __init__ for the class is empty. This fix add "pass"  in that case so that the produced python code is correct.