### PR TITLE
Fix case when object has no property

### DIFF
--- a/jsonschema2popo/_class.tmpl
+++ b/jsonschema2popo/_class.tmpl
@@ -26,6 +26,8 @@ class {{model.name}}:
             ):
 {% for prop in model.properties %}
         self.__{{prop._name}} = {{prop._name}}
+{% else %}
+        pass
 {% endfor %}
     
 {% for prop in model.properties %}


### PR DESCRIPTION
When an object has no property, the produced \_\_init__ for the class is empty. This fix add "pass" in that case so that the produced python code is correct.