### PR TITLE
Better Enum Support. Supports Inner Classes for Objects Defined Inline. Fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv/
 
 model.py
 *.json
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JSONSCHEMA2POPO
 
 A converter to extract 'Plain Old Python Object' classes from JSON Schema files.
-Currenty compatible with python 3.4+
+Currently compatible with python 3.4+
 
 ## Installation
 

--- a/jsonschema2popo/__init__.py
+++ b/jsonschema2popo/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-__version__ = '0.12'
+__version__ = "0.12"

--- a/jsonschema2popo/__init__.py
+++ b/jsonschema2popo/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-__version__ = "0.12"
+__version__ = "0.13"

--- a/jsonschema2popo/__main__.py
+++ b/jsonschema2popo/__main__.py
@@ -5,11 +5,11 @@ from __future__ import absolute_import
 import os
 import sys
 
-if __package__ == '':
+if __package__ == "":
     path = os.path.dirname(os.path.dirname(__file__))
     sys.path.insert(0, path)
 
 from jsonschema2popo.jsonschema2popo import main as _main  # noqa
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(_main())

--- a/jsonschema2popo/_class.tmpl
+++ b/jsonschema2popo/_class.tmpl
@@ -1,3 +1,14 @@
+{% macro type_check(prop, name=None) %}
+{% if prop._type and prop._type.type %}
+if not isinstance({% if name %}{{ name }}{% else %}{{ prop._name }}{% endif %}, {{prop._type.type.__name__ or prop._type.type}}):
+    raise TypeError("{{prop._name}} must be {{prop._type.type.__name__ or prop._type.type}}")
+{% endif %}
+{% if prop._type and prop._type.type.__name__ == 'list' and prop._type.subtype %}
+if not all(isinstance(i, {{prop._type.subtype.__name__ or prop._type.subtype}}) for i in {% if name %}{{ name }}{% else %}{{ prop._name }}{% endif %}):
+    raise TypeError("{{prop._name}} list values must be {{prop._type.subtype.__name__ or prop._type.subtype}}")
+{% endif %}
+{% endmacro %}
+
 #!/usr/bin/env/python
 
 {% if enum_used %}
@@ -38,8 +49,7 @@ class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
         pass
 {% if constructor_type_check %}
 {% for prop in model.properties %}
-        if not isinstance({{prop._name}}, {{prop._type.type.__name__ or prop._type.type}}):
-            raise TypeError("{{prop._name}} must be {{prop._type.type.__name__ or prop._type.type}}")
+        {{ type_check(prop)|indent(8) }}
 {% endfor %}
 {% endif %}
 {% for prop in model.properties %}
@@ -51,14 +61,7 @@ class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
     def _get_{{prop._name}}(self):
         return self.__{{prop._name}}
     def _set_{{prop._name}}(self, value):
-{% if prop._type and prop._type.type %}
-        if not isinstance(value, {{prop._type.type.__name__ or prop._type.type}}):
-            raise TypeError("{{prop._name}} must be {{prop._type.type.__name__ or prop._type.type}}")
-{% endif %}
-{% if prop._type and prop._type.type.__name__ == 'list' and prop._type.subtype %}
-        if not all(isinstance(i, {{prop._type.subtype.__name__ or prop._type.subtype}}) for i in value):
-            raise TypeError("{{prop._name}} list values must be {{prop._type.subtype.__name__ or prop._type.subtype}}")
-{% endif %}
+        {{ type_check(prop, "value")|indent(8) }}
 {% if prop._enum %}
         if value in self._{{prop._name}}_enum.__members__:
             self.__type = value

--- a/jsonschema2popo/_class.tmpl
+++ b/jsonschema2popo/_class.tmpl
@@ -27,6 +27,7 @@ class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
 {% endfor %}
     }
 
+{% if not model.enum %}
     def __init__(self
 {% for prop in model.properties %}
             , {{prop._name}}={{prop._default}}
@@ -36,6 +37,7 @@ class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
 {% for prop in model.properties %}
         self.__{{prop._name}} = {{prop._name}}
 {% endfor %}
+{% endif %}
     
 {% for prop in model.properties %}
     def _get_{{prop._name}}(self):
@@ -61,6 +63,9 @@ class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
     
 {% endfor %}
     def as_dict(self):
+{% if model.enum %}
+        return self.value
+{% else %}
         d = dict()
 {% for prop in model.properties %}
         if self.__{{prop._name}} is not None:
@@ -71,5 +76,9 @@ class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
 {% endif %}
 {% endfor %}
         return d
+{% endif %}
+
+    def __repr__(self):
+        return "<Class {{model.name}}. {{ model.properties|map(attribute="_name")|map('regex_replace', '(.+)', '\\1: {}')|join(', ') }}>".format({{ model.properties|map(attribute="_name")|map('regex_replace', '(.+)', 'self.__\\1')|join(', ') }})
 
 {% endfor %}

--- a/jsonschema2popo/_class.tmpl
+++ b/jsonschema2popo/_class.tmpl
@@ -79,6 +79,10 @@ class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
 {% endif %}
 
     def __repr__(self):
+{% if model.enum %}
+        return "<Enum {{model.name}}. {}: {}>".format(self.name, self.value)
+{% else %}
         return "<Class {{model.name}}. {{ model.properties|map(attribute="_name")|map('regex_replace', '(.+)', '\\1: {}')|join(', ') }}>".format({{ model.properties|map(attribute="_name")|map('regex_replace', '(.+)', 'self.__\\1')|join(', ') }})
+{% endif %}
 
 {% endfor %}

--- a/jsonschema2popo/_class.tmpl
+++ b/jsonschema2popo/_class.tmpl
@@ -6,10 +6,12 @@ import enum
 {% for model in models %}
 class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
 
-{% for value in model.enum if model.enum %}
-    {{value}} = {% if model.text_type == "string" %}"{{value}}"{% endif %}
+{% if model.enum %}
+{% for name, value in model.enum.items() %}
+    {{name}} = {% if model.text_type == "string" %}"{{value}}"{% elif model.text_type == "integer" or model.text_type == "number" %}{{value}}{% endif %}
 
 {% endfor %}
+{% endif %}
 
 {% for prop in model.properties if prop._enum %}
     _{{prop._name}}_enum = enum.Enum('_{{prop._name}}_enum', '{{prop._enum|join(' ')}}', module=__name__)

--- a/jsonschema2popo/_class.tmpl
+++ b/jsonschema2popo/_class.tmpl
@@ -1,11 +1,13 @@
+{% macro get_type(prop, parent=True, sub=True) %}{{ parent and prop._type.parent or sub and prop._type.subtype.__name__ or sub and prop._type.subtype or prop._type.type.__name__ or prop._type.type or None}}{% endmacro %}
+
 {% macro type_check(prop, name=None) %}
 {% if prop._type and prop._type.type %}
-if not isinstance({% if name %}{{ name }}{% else %}{{ prop._name }}{% endif %}, {% if prop._type.parent %}{{ prop._type.parent }}{% else %}{{prop._type.type.__name__ or prop._type.type}}{% endif %}):
-    raise TypeError("{{prop._name}} must be {{prop._type.type.__name__ or prop._type.type}}")
+if not isinstance({{ name or prop._name }}, {{ get_type(prop, sub=False) }}):
+    raise TypeError("{{prop._name}} must be {{ get_type(prop, sub=False) }}")
 {% endif %}
 {% if prop._type and prop._type.type.__name__ == 'list' and prop._type.subtype %}
-if not all(isinstance(i, {% if prop._type.parent %}{{ prop._type.parent }}{% else %}{{prop._type.subtype.__name__ or prop._type.subtype}}{% endif %}) for i in {% if name %}{{ name }}{% else %}{{ prop._name }}{% endif %}):
-    raise TypeError("{{prop._name}} list values must be {{prop._type.subtype.__name__ or prop._type.subtype}}")
+if not all(isinstance(i, {{ get_type(prop) }}) for i in {% if name %}{{ name }}{% else %}{{ prop._name }}{% endif %}):
+    raise TypeError("{{prop._name}} list values must be {{ get_type(prop) }}")
 {% endif %}
 {% endmacro %}
 
@@ -44,7 +46,7 @@ class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
 {% if not model.enum %}
     def __init__(self
 {% for prop in model.properties %}
-            , {{prop._name}}{% if use_types %}: {{prop._type.type.__name__ or prop._type.type}}{% endif %}={{prop._default}}
+            , {{prop._name}}{% if use_types %}: {{ get_type(prop, False) }}{% endif %}={{prop._default}}
 {% endfor %}
             ):
         pass
@@ -67,11 +69,31 @@ class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
     {{prop._name}} = property(_get_{{prop._name}}, _set_{{prop._name}})
     
 {% endfor %}
+
+    @staticmethod
+    def from_dict(d):
+{% if model.enum %}
+        return {{ model.parent or model.name }}(d)
+{% else %}
+        v = {}
+{% for prop in model.properties %}
+        if "{{ prop._name }}" in d:
+            {{ type_check(prop, "d[\"" + prop._name + "\"]")|indent(12) }}
+{% if prop._type.type.__name__ == 'list' %}
+            v["{{ prop._name }}"] = [{{ get_type(prop) }}.from_dict(p) if hasattr({{ get_type(prop) }}, 'from_dict') else p for p in d["{{ prop._name }}"]]
+{% else %}
+            v["{{ prop._name }}"] = {{ get_type(prop) }}.from_dict(d["{{prop._name}}"]) if hasattr({{ get_type(prop) }}, 'from_dict') else d["{{ prop._name }}"]
+{% endif %}
+{% endfor %}
+        return {{ model.parent or model.name }}(**v)
+{% endif %}
+
+
     def as_dict(self):
 {% if model.enum %}
         return self.value
 {% else %}
-        d = dict()
+        d = {}
 {% for prop in model.properties %}
         if self.__{{prop._name}} is not None:
 {% if prop._type.type.__name__ == 'list' %}

--- a/jsonschema2popo/_class.tmpl
+++ b/jsonschema2popo/_class.tmpl
@@ -26,6 +26,7 @@ class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
 {% endfor %}
 {% endif %}
 
+{% if model.properties %}
 {% for prop in model.properties if prop._enum %}
     _{{prop._name}}_enum = enum.Enum('_{{prop._name}}_enum', '{{prop._enum|join(' ')}}', module=__name__)
 {% endfor %}
@@ -39,6 +40,7 @@ class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
         '{{prop._name}}': '{{prop._format}}',
 {% endfor %}
     }
+{% endif %}
 
 {% if not model.enum %}
     def __init__(self

--- a/jsonschema2popo/_class.tmpl
+++ b/jsonschema2popo/_class.tmpl
@@ -1,6 +1,8 @@
 #!/usr/bin/env/python
 
+{% if enum_used %}
 import enum
+{% endif %}
 
 
 {% for model in models %}
@@ -30,10 +32,16 @@ class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
 {% if not model.enum %}
     def __init__(self
 {% for prop in model.properties %}
-            , {{prop._name}}={{prop._default}}
+            , {{prop._name}}{% if use_types %}: {{prop._type.type.__name__ or prop._type.type}}{% endif %}={{prop._default}}
 {% endfor %}
             ):
         pass
+{% if constructor_type_check %}
+{% for prop in model.properties %}
+        if not isinstance({{prop._name}}, {{prop._type.type.__name__ or prop._type.type}}):
+            raise TypeError("{{prop._name}} must be {{prop._type.type.__name__ or prop._type.type}}")
+{% endfor %}
+{% endif %}
 {% for prop in model.properties %}
         self.__{{prop._name}} = {{prop._name}}
 {% endfor %}

--- a/jsonschema2popo/_class.tmpl
+++ b/jsonschema2popo/_class.tmpl
@@ -23,6 +23,10 @@ class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
     {{ generate_class(subModel)|indent(8) }}
 {% endfor %}
 
+{% if use_slots and not model.enum %}
+    __slots__ = [{% for prop in model.properties %}"__{{ prop._name }}", {% endfor %}]
+{% endif %}
+
 {% if model.enum %}
 {% for name, value in model.enum.items() %}
     {{name}} = {% if model.text_type == "string" %}"{{value}}"{% elif model.text_type == "integer" or model.text_type == "number" %}{{value}}{% endif %}

--- a/jsonschema2popo/_class.tmpl
+++ b/jsonschema2popo/_class.tmpl
@@ -2,8 +2,14 @@
 
 import enum
 
+
 {% for model in models %}
-class {{model.name}}:
+class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
+
+{% for value in model.enum if model.enum %}
+    {{value}} = {% if model.text_type == "string" %}"{{value}}"{% endif %}
+
+{% endfor %}
 
 {% for prop in model.properties if prop._enum %}
     _{{prop._name}}_enum = enum.Enum('_{{prop._name}}_enum', '{{prop._enum|join(' ')}}', module=__name__)
@@ -24,6 +30,7 @@ class {{model.name}}:
             , {{prop._name}}={{prop._default}}
 {% endfor %}
             ):
+        pass
 {% for prop in model.properties %}
         self.__{{prop._name}} = {{prop._name}}
 {% endfor %}

--- a/jsonschema2popo/_class.tmpl
+++ b/jsonschema2popo/_class.tmpl
@@ -1,10 +1,10 @@
 {% macro type_check(prop, name=None) %}
 {% if prop._type and prop._type.type %}
-if not isinstance({% if name %}{{ name }}{% else %}{{ prop._name }}{% endif %}, {{prop._type.type.__name__ or prop._type.type}}):
+if not isinstance({% if name %}{{ name }}{% else %}{{ prop._name }}{% endif %}, {% if prop._type.parent %}{{ prop._type.parent }}{% else %}{{prop._type.type.__name__ or prop._type.type}}{% endif %}):
     raise TypeError("{{prop._name}} must be {{prop._type.type.__name__ or prop._type.type}}")
 {% endif %}
 {% if prop._type and prop._type.type.__name__ == 'list' and prop._type.subtype %}
-if not all(isinstance(i, {{prop._type.subtype.__name__ or prop._type.subtype}}) for i in {% if name %}{{ name }}{% else %}{{ prop._name }}{% endif %}):
+if not all(isinstance(i, {% if prop._type.parent %}{{ prop._type.parent }}{% else %}{{prop._type.subtype.__name__ or prop._type.subtype}}{% endif %}) for i in {% if name %}{{ name }}{% else %}{{ prop._name }}{% endif %}):
     raise TypeError("{{prop._name}} list values must be {{prop._type.subtype.__name__ or prop._type.subtype}}")
 {% endif %}
 {% endmacro %}
@@ -15,9 +15,11 @@ if not all(isinstance(i, {{prop._type.subtype.__name__ or prop._type.subtype}}) 
 import enum
 {% endif %}
 
-
-{% for model in models %}
+{% macro generate_class(model) %}
 class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
+{% for subModel in model.subModels %}
+    {{ generate_class(subModel)|indent(8) }}
+{% endfor %}
 
 {% if model.enum %}
 {% for name, value in model.enum.items() %}
@@ -87,5 +89,9 @@ class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
 {% else %}
         return "<Class {{model.name}}. {{ model.properties|map(attribute="_name")|map('regex_replace', '(.+)', '\\1: {}')|join(', ') }}>".format({{ model.properties|map(attribute="_name")|map('regex_replace', '(.+)', 'self.__\\1')|join(', ') }})
 {% endif %}
+{% endmacro %}
 
+
+{% for model in models %}
+{{ generate_class(model) }}
 {% endfor %}

--- a/jsonschema2popo/_class.tmpl
+++ b/jsonschema2popo/_class.tmpl
@@ -27,9 +27,6 @@ class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
 {% endif %}
 
 {% if model.properties %}
-{% for prop in model.properties if prop._enum %}
-    _{{prop._name}}_enum = enum.Enum('_{{prop._name}}_enum', '{{prop._enum|join(' ')}}', module=__name__)
-{% endfor %}
     _types_map = {
 {% for prop in model.properties %}
         '{{prop._name}}': {'type': {{prop._type.type.__name__ or prop._type.type or None}}, 'subtype': {{prop._type.subtype.__name__ or prop._type.subtype or None}}},
@@ -64,14 +61,7 @@ class {{model.name}}{% if model.enum %}(enum.Enum){% endif %}:
         return self.__{{prop._name}}
     def _set_{{prop._name}}(self, value):
         {{ type_check(prop, "value")|indent(8) }}
-{% if prop._enum %}
-        if value in self._{{prop._name}}_enum.__members__:
-            self.__type = value
-        else:
-            raise ValueError("Value {} not in _{{prop._name}}_enum list".format(value))
-{% else %}
         self.__{{prop._name}} = value
-{% endif %}
     {{prop._name}} = property(_get_{{prop._name}}, _set_{{prop._name}})
     
 {% endfor %}

--- a/jsonschema2popo/jsonschema2popo.py
+++ b/jsonschema2popo/jsonschema2popo.py
@@ -8,24 +8,27 @@ from jinja2 import Environment, FileSystemLoader
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
+
 class JsonSchema2Popo:
     """Converts a JSON Schema to a Plain Old Python Object class"""
 
-    CLASS_TEMPLATE_FNAME = '_class.tmpl'
+    CLASS_TEMPLATE_FNAME = "_class.tmpl"
 
     J2P_TYPES = {
-        'string': str,
-        'integer': int,
-        'number': float,
-        'object': type,
-        'array': list,
-        'boolean': bool,
-        'null': None
+        "string": str,
+        "integer": int,
+        "number": float,
+        "object": type,
+        "array": list,
+        "boolean": bool,
+        "null": None,
     }
-    
+
     def __init__(self):
-        self.jinja = Environment(loader=FileSystemLoader(searchpath=SCRIPT_DIR), trim_blocks=True)
-        
+        self.jinja = Environment(
+            loader=FileSystemLoader(searchpath=SCRIPT_DIR), trim_blocks=True
+        )
+
         self.definitions = []
 
     def load(self, json_schema_file):
@@ -33,133 +36,169 @@ class JsonSchema2Popo:
 
     def get_model_depencencies(self, model):
         deps = set()
-        for prop in model['properties']:
-            if prop['_type']['type'] not in self.J2P_TYPES.values():
-                deps.add(prop['_type']['type'])
-            if prop['_type']['subtype'] not in self.J2P_TYPES.values():
-                deps.add(prop['_type']['subtype'])
+        for prop in model["properties"]:
+            if prop["_type"]["type"] not in self.J2P_TYPES.values():
+                deps.add(prop["_type"]["type"])
+            if prop["_type"]["subtype"] not in self.J2P_TYPES.values():
+                deps.add(prop["_type"]["subtype"])
         return list(deps)
 
     def process(self, json_schema):
-        for _obj_name, _obj in json_schema['definitions'].items():
+        for _obj_name, _obj in json_schema["definitions"].items():
             model = self.definition_parser(_obj_name, _obj)
             self.definitions.append(model)
-        
+
         # topological oderd dependencies
         g = networkx.DiGraph()
         models_map = {}
         for model in self.definitions:
-            models_map[model['name']] = model
+            models_map[model["name"]] = model
             deps = self.get_model_depencencies(model)
             if not deps:
-                g.add_edge(model['name'], '')
+                g.add_edge(model["name"], "")
             for dep in deps:
-                g.add_edge(model['name'], dep)
-        
+                g.add_edge(model["name"], dep)
+
         self.definitions = []
         for model_name in networkx.topological_sort(g, reverse=True):
             if model_name in models_map:
                 self.definitions.append(models_map[model_name])
-        
+
         # root object
-        if 'title' in json_schema:
-            root_object_name = ''.join(x for x in json_schema['title'].title() if x.isalpha())
+        if "title" in json_schema:
+            root_object_name = "".join(
+                x for x in json_schema["title"].title() if x.isalpha()
+            )
         else:
-            root_object_name = 'RootObject'
+            root_object_name = "RootObject"
         root_model = self.definition_parser(root_object_name, json_schema)
         self.definitions.append(root_model)
 
     def definition_parser(self, _obj_name, _obj):
-        model = {}
-        model['name'] = _obj_name
-        if 'type' in _obj:
-            model['type'] = self.type_parser(_obj)
-            model['text_type'] = _obj['type']
+        model = {"name": _obj_name}
+        if "type" in _obj:
+            model["type"] = self.type_parser(_obj)
+            model["text_type"] = _obj["type"]
 
-        if 'enum' in _obj:
-            model['enum'] = _obj['enum']
+        if "enum" in _obj:
+            enum = {}
+            for i, v in enumerate(_obj["enum"]):
+                enum[v if "javaEnumNames" not in _obj else _obj["javaEnumNames"][i]] = v
+            model["enum"] = enum
 
-        model['properties'] = []
-        if 'properties' in _obj:
-            for _prop_name, _prop in _obj['properties'].items():
+        model["properties"] = []
+        if "properties" in _obj:
+            for _prop_name, _prop in _obj["properties"].items():
                 _type = self.type_parser(_prop)
                 _default = None
-                if 'default' in _prop:
-                    _default = _type['type'](_prop['default'])
-                    if _type['type'] == str:
+                if "default" in _prop:
+                    _default = _type["type"](_prop["default"])
+                    if _type["type"] == str:
                         _default = "'{}'".format(_default)
 
                 _enum = None
-                if 'enum' in _prop:
-                    _enum = _prop['enum']
-                
+                if "enum" in _prop:
+                    _enum = _prop["enum"]
+
                 _format = None
-                if 'format' in _prop:
-                    _format = _prop['format']
-                if _type['type'] == list and 'items' in _prop and isinstance(_prop['items'], list):
-                    _format = _prop['items'][0]['format']
-                
+                if "format" in _prop:
+                    _format = _prop["format"]
+                if (
+                    _type["type"] == list
+                    and "items" in _prop
+                    and isinstance(_prop["items"], list)
+                ):
+                    _format = _prop["items"][0]["format"]
+
                 prop = {
-                    '_name': _prop_name,
-                    '_type': _type,
-                    '_default': _default,
-                    '_enum': _enum,
-                    '_format' : _format
+                    "_name": _prop_name,
+                    "_type": _type,
+                    "_default": _default,
+                    "_enum": _enum,
+                    "_format": _format,
                 }
-                model['properties'].append(prop)
+                model["properties"].append(prop)
         return model
 
     def type_parser(self, t):
         _type = None
         _subtype = None
-        if 'type' in t:
-            if t['type'] == 'array' and 'items' in t:
-                _type = self.J2P_TYPES[t['type']]
-                if isinstance(t['items'], list):
-                    if 'type' in t['items'][0]:
-                        _subtype = self.J2P_TYPES[t['items'][0]['type']]
-                    elif '$ref' in t['items'][0] or 'oneOf' in t['items'][0] and len(t['items'][0]['oneOf']) == 1:
-                        if '$ref' in t['items'][0]:
-                            ref = t['items'][0]['$ref']
+        if "type" in t:
+            if t["type"] == "array" and "items" in t:
+                _type = self.J2P_TYPES[t["type"]]
+                if isinstance(t["items"], list):
+                    if "type" in t["items"][0]:
+                        _subtype = self.J2P_TYPES[t["items"][0]["type"]]
+                    elif (
+                        "$ref" in t["items"][0]
+                        or "oneOf" in t["items"][0]
+                        and len(t["items"][0]["oneOf"]) == 1
+                    ):
+                        if "$ref" in t["items"][0]:
+                            ref = t["items"][0]["$ref"]
                         else:
-                            ref = t['items'][0]['oneOf'][0]['$ref']
-                        _subtype = ref.split('/')[-1]
-                elif isinstance(t['items'], dict):
-                    if 'type' in t['items']:
-                        _subtype = self.J2P_TYPES[t['items']['type']]
-                    elif '$ref' in t['items'] or 'oneOf' in t['items'] and len(t['items']['oneOf']) == 1:
-                        if '$ref' in t['items']:
-                            ref = t['items']['$ref']
+                            ref = t["items"][0]["oneOf"][0]["$ref"]
+                        _subtype = ref.split("/")[-1]
+                elif isinstance(t["items"], dict):
+                    if "type" in t["items"]:
+                        _subtype = self.J2P_TYPES[t["items"]["type"]]
+                    elif (
+                        "$ref" in t["items"]
+                        or "oneOf" in t["items"]
+                        and len(t["items"]["oneOf"]) == 1
+                    ):
+                        if "$ref" in t["items"]:
+                            ref = t["items"]["$ref"]
                         else:
-                            ref = t['items']['oneOf'][0]['$ref']
-                        _subtype = ref.split('/')[-1]
-            elif isinstance(t['type'], list):
-                _type = self.J2P_TYPES[t['type'][0]]
-            elif t['type']:
-                _type = self.J2P_TYPES[t['type']]
-        elif '$ref' in t:
-            _type = t['$ref'].split('/')[-1]
-        elif 'anyOf' in t or  'allOf' in t or  'oneOf' in t:
+                            ref = t["items"]["oneOf"][0]["$ref"]
+                        _subtype = ref.split("/")[-1]
+            elif isinstance(t["type"], list):
+                _type = self.J2P_TYPES[t["type"][0]]
+            elif t["type"]:
+                _type = self.J2P_TYPES[t["type"]]
+        elif "$ref" in t:
+            _type = t["$ref"].split("/")[-1]
+        elif "anyOf" in t or "allOf" in t or "oneOf" in t:
             _type = list
-        return { 'type': _type, 'subtype': _subtype }
+        return {"type": _type, "subtype": _subtype}
 
     def write_file(self, filename):
-        self.jinja.get_template(self.CLASS_TEMPLATE_FNAME).stream(models=self.definitions).dump(filename)
+        self.jinja.get_template(self.CLASS_TEMPLATE_FNAME).stream(
+            models=self.definitions
+        ).dump(filename)
+
 
 class readable_dir(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
-        prospective_dir=values
+        prospective_dir = values
         if not os.path.isdir(prospective_dir):
-            raise argparse.ArgumentTypeError("readable_dir:{} is not a valid path".format(prospective_dir))
+            raise argparse.ArgumentTypeError(
+                "readable_dir:{} is not a valid path".format(prospective_dir)
+            )
         if os.access(prospective_dir, os.R_OK):
             setattr(namespace, self.dest, prospective_dir)
         else:
-            raise argparse.ArgumentTypeError("readable_dir:{} is not a readable dir".format(prospective_dir))
+            raise argparse.ArgumentTypeError(
+                "readable_dir:{} is not a readable dir".format(prospective_dir)
+            )
+
 
 def init_parser():
-    parser = argparse.ArgumentParser(description="Converts JSON Schema to Plain Old Python Object")
-    parser.add_argument('json_schema_file', type=argparse.FileType('r', encoding='utf-8'), help="Path to JSON Schema file to load")
-    parser.add_argument('-o', '--output-file', type=argparse.FileType('w', encoding='utf-8'), help="Path to file output", default="model.py")
+    parser = argparse.ArgumentParser(
+        description="Converts JSON Schema to Plain Old Python Object"
+    )
+    parser.add_argument(
+        "json_schema_file",
+        type=argparse.FileType("r", encoding="utf-8"),
+        help="Path to JSON Schema file to load",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-file",
+        type=argparse.FileType("w", encoding="utf-8"),
+        help="Path to file output",
+        default="model.py",
+    )
     return parser
 
 
@@ -173,5 +212,6 @@ def main():
     outfile = args.output_file
     loader.write_file(outfile)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/jsonschema2popo/jsonschema2popo.py
+++ b/jsonschema2popo/jsonschema2popo.py
@@ -29,9 +29,11 @@ class JsonSchema2Popo:
 
     def __init__(self):
         self.jinja = Environment(
-            loader=FileSystemLoader(searchpath=SCRIPT_DIR), trim_blocks=True,
+            loader=FileSystemLoader(searchpath=SCRIPT_DIR), trim_blocks=True
         )
-        self.jinja.filters['regex_replace'] = lambda s, find, replace: re.sub(find, replace, s)
+        self.jinja.filters["regex_replace"] = lambda s, find, replace: re.sub(
+            find, replace, s
+        )
 
         self.definitions = []
 
@@ -219,7 +221,13 @@ def main():
 
     try:
         import black
-        black.format_file_in_place(pathlib.Path(outfile.name).absolute(), 120, fast=True, write_back=black.WriteBack.YES)
+
+        black.format_file_in_place(
+            pathlib.Path(outfile.name).absolute(),
+            120,
+            fast=True,
+            write_back=black.WriteBack.YES,
+        )
     except:
         pass
 

--- a/jsonschema2popo/jsonschema2popo.py
+++ b/jsonschema2popo/jsonschema2popo.py
@@ -74,6 +74,10 @@ class JsonSchema2Popo:
         model['name'] = _obj_name
         if 'type' in _obj:
             model['type'] = self.type_parser(_obj)
+            model['text_type'] = _obj['type']
+
+        if 'enum' in _obj:
+            model['enum'] = _obj['enum']
 
         model['properties'] = []
         if 'properties' in _obj:

--- a/jsonschema2popo/jsonschema2popo.py
+++ b/jsonschema2popo/jsonschema2popo.py
@@ -4,6 +4,7 @@ import os
 import argparse
 import json
 import re
+import pathlib
 
 import networkx
 from jinja2 import Environment, FileSystemLoader
@@ -51,7 +52,7 @@ class JsonSchema2Popo:
             model = self.definition_parser(_obj_name, _obj)
             self.definitions.append(model)
 
-        # topological oderd dependencies
+        # topological ordered dependencies
         g = networkx.DiGraph()
         models_map = {}
         for model in self.definitions:
@@ -169,6 +170,7 @@ class JsonSchema2Popo:
         self.jinja.get_template(self.CLASS_TEMPLATE_FNAME).stream(
             models=self.definitions
         ).dump(filename)
+        filename.close()
 
 
 class readable_dir(argparse.Action):
@@ -214,6 +216,12 @@ def main():
 
     outfile = args.output_file
     loader.write_file(outfile)
+
+    try:
+        import black
+        black.format_file_in_place(pathlib.Path(outfile.name).absolute(), 120, fast=True, write_back=black.WriteBack.YES)
+    except:
+        pass
 
 
 if __name__ == "__main__":

--- a/jsonschema2popo/jsonschema2popo.py
+++ b/jsonschema2popo/jsonschema2popo.py
@@ -271,21 +271,6 @@ class JsonSchema2Popo:
             filename.close()
 
 
-class readable_dir(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        prospective_dir = values
-        if not os.path.isdir(prospective_dir):
-            raise argparse.ArgumentTypeError(
-                "readable_dir:{} is not a valid path".format(prospective_dir)
-            )
-        if os.access(prospective_dir, os.R_OK):
-            setattr(namespace, self.dest, prospective_dir)
-        else:
-            raise argparse.ArgumentTypeError(
-                "readable_dir:{} is not a readable dir".format(prospective_dir)
-            )
-
-
 def init_parser():
     parser = argparse.ArgumentParser(
         description="Converts JSON Schema to Plain Old Python Object"

--- a/jsonschema2popo/jsonschema2popo.py
+++ b/jsonschema2popo/jsonschema2popo.py
@@ -35,7 +35,7 @@ class JsonSchema2Popo:
         else:
             yield something
 
-    def __init__(self, use_types=False, constructor_type_check=False):
+    def __init__(self, use_types=False, constructor_type_check=False, use_slots=False):
         self.enum_used = False
         self.jinja = Environment(
             loader=FileSystemLoader(searchpath=SCRIPT_DIR), trim_blocks=True
@@ -43,8 +43,8 @@ class JsonSchema2Popo:
         self.jinja.filters["regex_replace"] = lambda s, find, replace: re.sub(
             find, replace, s
         )
-        self.jinja.filters["any"] = any
         self.use_types = use_types
+        self.use_slots = use_slots
         self.constructor_type_check = constructor_type_check
 
         self.definitions = []
@@ -266,6 +266,7 @@ class JsonSchema2Popo:
             use_types=self.use_types,
             constructor_type_check=self.constructor_type_check,
             enum_used=self.enum_used,
+            use_slots=self.use_slots,
         ).dump(filename)
         if hasattr(filename, "close"):
             filename.close()
@@ -294,6 +295,9 @@ def init_parser():
         action="store_true",
         help="Validate input types in constructor",
     )
+    parser.add_argument(
+        "-s", "--use_slots", action="store_true", help="Generate class with __slots__."
+    )
     return parser
 
 
@@ -316,7 +320,9 @@ def main():
     args = parser.parse_args()
 
     loader = JsonSchema2Popo(
-        use_types=args.use_types, constructor_type_check=args.constructor_type_check
+        use_types=args.use_types,
+        constructor_type_check=args.constructor_type_check,
+        use_slots=args.use_slots,
     )
     loader.load(args.json_schema_file)
 

--- a/jsonschema2popo/jsonschema2popo.py
+++ b/jsonschema2popo/jsonschema2popo.py
@@ -3,6 +3,8 @@
 import os
 import argparse
 import json
+import re
+
 import networkx
 from jinja2 import Environment, FileSystemLoader
 
@@ -26,8 +28,9 @@ class JsonSchema2Popo:
 
     def __init__(self):
         self.jinja = Environment(
-            loader=FileSystemLoader(searchpath=SCRIPT_DIR), trim_blocks=True
+            loader=FileSystemLoader(searchpath=SCRIPT_DIR), trim_blocks=True,
         )
+        self.jinja.filters['regex_replace'] = lambda s, find, replace: re.sub(find, replace, s)
 
         self.definitions = []
 

--- a/setup.py
+++ b/setup.py
@@ -5,43 +5,47 @@ import re
 
 here = os.path.abspath(os.path.dirname(__file__))
 
+
 def read(*parts):
-    with codecs.open(os.path.join(here, *parts), 'r') as fp:
+    with codecs.open(os.path.join(here, *parts), "r") as fp:
         return fp.read()
+
 
 def find_version(*file_paths):
     version_file = read(*file_paths)
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              version_file, re.M)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
 
+
 setup(
-        name='jsonschema2popo',
-        version=find_version("jsonschema2popo", "__init__.py"),
-        description='Converts a JSON Schema to a Plain Old Python Object class',
-        long_description=read('README.md'),
-        long_description_content_type='text/markdown',
-        classifiers=[
-            "Development Status :: 5 - Production/Stable",
-            "Intended Audience :: Developers",
-            "License :: OSI Approved :: MIT License",
-            "Topic :: Software Development :: Build Tools",
-            "Programming Language :: Python :: 3.4",
-            "Programming Language :: Python :: 3.5",
-            "Programming Language :: Python :: 3.6",
-            "Programming Language :: Python :: Implementation :: PyPy",
-        ],
-        url='https://github.com/frx08/jsonschema2popo',
-        author='cruc.io',
-        author_email='frx089@gmail.com',
-        keywords='python json-schema code-generator',
-        license='MIT License',
-        python_requires='>=3.4',
-        install_requires=['Jinja2>=2.10', 'networkx==1.9'],
-        packages=["jsonschema2popo"],
-        package_data={"jsonschema2popo": ["_class.tmpl"]},
-        include_package_data=True,
-        entry_points={"console_scripts": ["jsonschema2popo=jsonschema2popo.jsonschema2popo:main"]},
+    name="jsonschema2popo",
+    version=find_version("jsonschema2popo", "__init__.py"),
+    description="Converts a JSON Schema to a Plain Old Python Object class",
+    long_description=read("README.md"),
+    long_description_content_type="text/markdown",
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Topic :: Software Development :: Build Tools",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: Implementation :: PyPy",
+    ],
+    url="https://github.com/frx08/jsonschema2popo",
+    author="cruc.io",
+    author_email="frx089@gmail.com",
+    keywords="python json-schema code-generator",
+    license="MIT License",
+    python_requires=">=3.4",
+    install_requires=["Jinja2>=2.10", "networkx==1.9"],
+    packages=["jsonschema2popo"],
+    package_data={"jsonschema2popo": ["_class.tmpl"]},
+    include_package_data=True,
+    entry_points={
+        "console_scripts": ["jsonschema2popo=jsonschema2popo.jsonschema2popo:main"]
+    },
 )

--- a/test/test_jsonschema2popo.py
+++ b/test/test_jsonschema2popo.py
@@ -1,0 +1,258 @@
+import io
+import json
+import os
+import unittest
+from jsonschema2popo import jsonschema2popo
+from jsonschema2popo.jsonschema2popo import format_file
+
+
+class JsonSchema2Popo(unittest.TestCase):
+    test_file = "test_output.py"
+
+    def tearDown(self):
+        os.remove(self.test_file)
+
+    def test_root_basic_generation(self):
+        loader = jsonschema2popo.JsonSchema2Popo(
+            use_types=False, constructor_type_check=False
+        )
+        loader.process(
+            json.loads(
+                """{
+            "title": "ABcd",
+            "type": "object",
+            "properties": {
+                "Int": {
+                    "type": "integer"
+                },
+                "Float": {
+                    "type": "number"
+                },
+                "ListInt": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "String": {
+                    "type": "string"
+                },
+                "Object": {
+                    "type": "object"
+                }
+            }
+        }"""
+            )
+        )
+        loader.write_file(self.test_file)
+        format_file(self.test_file)
+        self.assertFileEqual(self.test_file, "valid/test_root_basic_generation.py")
+
+    def test_root_string_enum(self):
+        loader = jsonschema2popo.JsonSchema2Popo(
+            use_types=False, constructor_type_check=False
+        )
+        loader.process(
+            json.loads(
+                """{
+            "title": "ABcd",
+            "type": "string",
+            "enum": ["A", "B", "C"]
+        }"""
+            )
+        )
+        loader.write_file(self.test_file)
+        format_file(self.test_file)
+        self.assertFileEqual(self.test_file, "valid/test_root_string_enum.py")
+
+    def test_root_integer_enum(self):
+        loader = jsonschema2popo.JsonSchema2Popo(
+            use_types=False, constructor_type_check=False
+        )
+        loader.process(
+            json.loads(
+                """{
+            "title": "ABcd",
+            "type": "integer",
+            "enum": [0, 1, 2, 3],
+            "javaEnumNames": ["A", "B", "C", "D"]
+        }"""
+            )
+        )
+        loader.write_file(self.test_file)
+        format_file(self.test_file)
+        self.assertFileEqual(self.test_file, "valid/test_root_integer_enum.py")
+
+    def test_root_nested_objects(self):
+        loader = jsonschema2popo.JsonSchema2Popo(
+            use_types=False, constructor_type_check=False
+        )
+        loader.process(
+            json.loads(
+                """{
+            "title": "ABcd",
+            "type": "object",
+            "properties": {
+                "Child1": {
+                    "type": "object",
+                    "properties": {
+                        "IntVal": {
+                            "type": "integer"
+                        },
+                        "Child2": {
+                            "type": "object",
+                            "properties": {
+                                "IntVal": {
+                                    "type": "integer"
+                                },
+                                "ListVal": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }"""
+            )
+        )
+        loader.write_file(self.test_file)
+        format_file(self.test_file)
+        self.assertFileEqual(self.test_file, "valid/test_root_nested_objects.py")
+
+    def test_definitions_basic_generation(self):
+        loader = jsonschema2popo.JsonSchema2Popo(
+            use_types=False, constructor_type_check=False
+        )
+        loader.process(
+            json.loads(
+                """{
+            "definitions": {
+                "ABcd": {
+                    "type": "object",
+                    "properties": {
+                        "Int": {
+                            "type": "integer"
+                        },
+                        "Float": {
+                            "type": "number"
+                        },
+                        "ListInt": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "String": {
+                            "type": "string"
+                        },
+                        "Object": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        }"""
+            )
+        )
+        loader.write_file(self.test_file)
+        format_file(self.test_file)
+        self.assertFileEqual(
+            self.test_file, "valid/test_definitions_basic_generation.py"
+        )
+
+    def test_definitions_string_enum(self):
+        loader = jsonschema2popo.JsonSchema2Popo(
+            use_types=False, constructor_type_check=False
+        )
+        loader.process(
+            json.loads(
+                """{
+            "definitions": {
+                "ABcd": {
+                    "type": "string",
+                    "enum": ["A", "B", "C"]
+                }
+            }
+        }"""
+            )
+        )
+        loader.write_file(self.test_file)
+        format_file(self.test_file)
+        self.assertFileEqual(self.test_file, "valid/test_definitions_string_enum.py")
+
+    def test_definitions_integer_enum(self):
+        loader = jsonschema2popo.JsonSchema2Popo(
+            use_types=False, constructor_type_check=False
+        )
+        loader.process(
+            json.loads(
+                """{
+            "definitions": {
+                "ABcd": {
+                    "type": "integer",
+                    "enum": [0, 1, 2, 3],
+                    "javaEnumNames": ["A", "B", "C", "D"]
+                }
+            }
+        }"""
+            )
+        )
+        loader.write_file(self.test_file)
+        format_file(self.test_file)
+        self.assertFileEqual(self.test_file, "valid/test_definitions_integer_enum.py")
+
+    def test_definitions_nested_objects(self):
+        loader = jsonschema2popo.JsonSchema2Popo(
+            use_types=False, constructor_type_check=False
+        )
+        loader.process(
+            json.loads(
+                """{
+            "definitions": {
+                "ABcd": {
+                    "type": "object",
+                    "properties": {
+                        "Child1": {
+                            "type": "object",
+                            "properties": {
+                                "IntVal": {
+                                    "type": "integer"
+                                },
+                                "Child2": {
+                                    "type": "object",
+                                    "properties": {
+                                        "IntVal": {
+                                            "type": "integer"
+                                        },
+                                        "ListVal": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }"""
+            )
+        )
+        loader.write_file(self.test_file)
+        format_file(self.test_file)
+        self.assertFileEqual(self.test_file, "valid/test_definitions_nested_objects.py")
+
+    def assertFileEqual(self, filename1, filename2, message=""):
+        with io.open(filename1) as f1:
+            with io.open(filename2) as f2:
+                self.assertListEqual(list(f1), list(f2), message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_jsonschema2popo.py
+++ b/test/test_jsonschema2popo.py
@@ -248,6 +248,103 @@ class JsonSchema2Popo(unittest.TestCase):
         format_file(self.test_file)
         self.assertFileEqual(self.test_file, "valid/test_definitions_nested_objects.py")
 
+    def test_definitions_with_refs(self):
+        loader = jsonschema2popo.JsonSchema2Popo(
+            use_types=False, constructor_type_check=False
+        )
+        loader.process(
+            json.loads(
+                """{
+            "definitions": {
+                "ABcd": {
+                    "type": "object",
+                    "properties": {
+                        "Child1": {
+                            "type": "integer"
+                        },
+                        "Child2": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "SubRef": {
+                    "type": "object",
+                    "properties": {
+                        "ChildA": {
+                            "$ref": "#/definitions/ABcd"
+                        }
+                    }
+                },
+                "DirectRef": {
+                    "$ref": "#/definitions/ABcd"
+                }
+            }
+        }"""
+            )
+        )
+        loader.write_file(self.test_file)
+        format_file(self.test_file)
+        self.assertFileEqual(self.test_file, "valid/test_definitions_with_refs.py")
+
+    def test_definitions_with_nested_refs(self):
+        loader = jsonschema2popo.JsonSchema2Popo(
+            use_types=False, constructor_type_check=False
+        )
+        loader.process(
+            json.loads(
+                """{
+            "definitions": {
+                "ABcd": {
+                    "type": "object",
+                    "properties": {
+                        "Child1": {
+                            "type": "object",
+                            "properties": {
+                                "IntVal": {
+                                    "type": "integer"
+                                },
+                                "Child2": {
+                                    "type": "object",
+                                    "properties": {
+                                        "IntVal": {
+                                            "type": "integer"
+                                        },
+                                        "ListVal": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "Ref": {
+                    "$ref": "#/definitions/ABcd/Child1/Child2"
+                },
+                "AAAA": {
+                    "type": "object",
+                    "properties": {
+                        "X": {
+                            "type": "integer"
+                        },
+                        "YRef": {
+                            "$ref": "#/definitions/ABcd/Child1/Child2"
+                        }
+                    }
+                }
+            }
+        }"""
+            )
+        )
+        loader.write_file(self.test_file)
+        format_file(self.test_file)
+        self.assertFileEqual(
+            self.test_file, "valid/test_definitions_with_nested_refs.py"
+        )
+
     def assertFileEqual(self, filename1, filename2, message=""):
         with io.open(filename1) as f1:
             with io.open(filename2) as f2:

--- a/test/valid/test_definitions_basic_generation.py
+++ b/test/valid/test_definitions_basic_generation.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env/python
+
+
+class ABcd:
+    class _Object:
+        def __init__(self):
+            pass
+
+        def as_dict(self):
+            d = dict()
+            return d
+
+        def __repr__(self):
+            return "<Class _Object. >".format()
+
+    _types_map = {
+        "Int": {"type": int, "subtype": None},
+        "Float": {"type": float, "subtype": None},
+        "ListInt": {"type": list, "subtype": int},
+        "String": {"type": str, "subtype": None},
+        "Object": {"type": _Object, "subtype": None},
+    }
+    _formats_map = {}
+
+    def __init__(self, Int=None, Float=None, ListInt=None, String=None, Object=None):
+        pass
+        self.__Int = Int
+        self.__Float = Float
+        self.__ListInt = ListInt
+        self.__String = String
+        self.__Object = Object
+
+    def _get_Int(self):
+        return self.__Int
+
+    def _set_Int(self, value):
+        if not isinstance(value, int):
+            raise TypeError("Int must be int")
+
+        self.__Int = value
+
+    Int = property(_get_Int, _set_Int)
+
+    def _get_Float(self):
+        return self.__Float
+
+    def _set_Float(self, value):
+        if not isinstance(value, float):
+            raise TypeError("Float must be float")
+
+        self.__Float = value
+
+    Float = property(_get_Float, _set_Float)
+
+    def _get_ListInt(self):
+        return self.__ListInt
+
+    def _set_ListInt(self, value):
+        if not isinstance(value, list):
+            raise TypeError("ListInt must be list")
+        if not all(isinstance(i, int) for i in value):
+            raise TypeError("ListInt list values must be int")
+
+        self.__ListInt = value
+
+    ListInt = property(_get_ListInt, _set_ListInt)
+
+    def _get_String(self):
+        return self.__String
+
+    def _set_String(self, value):
+        if not isinstance(value, str):
+            raise TypeError("String must be str")
+
+        self.__String = value
+
+    String = property(_get_String, _set_String)
+
+    def _get_Object(self):
+        return self.__Object
+
+    def _set_Object(self, value):
+        if not isinstance(value, ABcd._Object):
+            raise TypeError("Object must be _Object")
+
+        self.__Object = value
+
+    Object = property(_get_Object, _set_Object)
+
+    def as_dict(self):
+        d = dict()
+        if self.__Int is not None:
+            d["Int"] = (
+                self.__Int.as_dict() if hasattr(self.__Int, "as_dict") else self.__Int
+            )
+        if self.__Float is not None:
+            d["Float"] = (
+                self.__Float.as_dict()
+                if hasattr(self.__Float, "as_dict")
+                else self.__Float
+            )
+        if self.__ListInt is not None:
+            d["ListInt"] = [
+                p.as_dict() if hasattr(p, "as_dict") else p for p in self.__ListInt
+            ]
+        if self.__String is not None:
+            d["String"] = (
+                self.__String.as_dict()
+                if hasattr(self.__String, "as_dict")
+                else self.__String
+            )
+        if self.__Object is not None:
+            d["Object"] = (
+                self.__Object.as_dict()
+                if hasattr(self.__Object, "as_dict")
+                else self.__Object
+            )
+        return d
+
+    def __repr__(self):
+        return "<Class ABcd. Int: {}, Float: {}, ListInt: {}, String: {}, Object: {}>".format(
+            self.__Int, self.__Float, self.__ListInt, self.__String, self.__Object
+        )
+
+
+class RootObject:
+    def __init__(self):
+        pass
+
+    def as_dict(self):
+        d = dict()
+        return d
+
+    def __repr__(self):
+        return "<Class RootObject. >".format()

--- a/test/valid/test_definitions_basic_generation.py
+++ b/test/valid/test_definitions_basic_generation.py
@@ -6,8 +6,13 @@ class ABcd:
         def __init__(self):
             pass
 
+        @staticmethod
+        def from_dict(d):
+            v = {}
+            return ABcd._Object(**v)
+
         def as_dict(self):
-            d = dict()
+            d = {}
             return d
 
         def __repr__(self):
@@ -81,14 +86,61 @@ class ABcd:
 
     def _set_Object(self, value):
         if not isinstance(value, ABcd._Object):
-            raise TypeError("Object must be _Object")
+            raise TypeError("Object must be ABcd._Object")
 
         self.__Object = value
 
     Object = property(_get_Object, _set_Object)
 
+    @staticmethod
+    def from_dict(d):
+        v = {}
+        if "Int" in d:
+            if not isinstance(d["Int"], int):
+                raise TypeError("Int must be int")
+
+            v["Int"] = (
+                int.from_dict(d["Int"]) if hasattr(int, "from_dict") else d["Int"]
+            )
+        if "Float" in d:
+            if not isinstance(d["Float"], float):
+                raise TypeError("Float must be float")
+
+            v["Float"] = (
+                float.from_dict(d["Float"])
+                if hasattr(float, "from_dict")
+                else d["Float"]
+            )
+        if "ListInt" in d:
+            if not isinstance(d["ListInt"], list):
+                raise TypeError("ListInt must be list")
+            if not all(isinstance(i, int) for i in d["ListInt"]):
+                raise TypeError("ListInt list values must be int")
+
+            v["ListInt"] = [
+                int.from_dict(p) if hasattr(int, "from_dict") else p
+                for p in d["ListInt"]
+            ]
+        if "String" in d:
+            if not isinstance(d["String"], str):
+                raise TypeError("String must be str")
+
+            v["String"] = (
+                str.from_dict(d["String"]) if hasattr(str, "from_dict") else d["String"]
+            )
+        if "Object" in d:
+            if not isinstance(d["Object"], ABcd._Object):
+                raise TypeError("Object must be ABcd._Object")
+
+            v["Object"] = (
+                ABcd._Object.from_dict(d["Object"])
+                if hasattr(ABcd._Object, "from_dict")
+                else d["Object"]
+            )
+        return ABcd(**v)
+
     def as_dict(self):
-        d = dict()
+        d = {}
         if self.__Int is not None:
             d["Int"] = (
                 self.__Int.as_dict() if hasattr(self.__Int, "as_dict") else self.__Int
@@ -127,8 +179,13 @@ class RootObject:
     def __init__(self):
         pass
 
+    @staticmethod
+    def from_dict(d):
+        v = {}
+        return RootObject(**v)
+
     def as_dict(self):
-        d = dict()
+        d = {}
         return d
 
     def __repr__(self):

--- a/test/valid/test_definitions_integer_enum.py
+++ b/test/valid/test_definitions_integer_enum.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env/python
+
+import enum
+
+
+class ABcd(enum.Enum):
+
+    A = 0
+    B = 1
+    C = 2
+    D = 3
+
+    def as_dict(self):
+        return self.value
+
+    def __repr__(self):
+        return "<Enum ABcd. {}: {}>".format(self.name, self.value)
+
+
+class RootObject:
+    def __init__(self):
+        pass
+
+    def as_dict(self):
+        d = dict()
+        return d
+
+    def __repr__(self):
+        return "<Class RootObject. >".format()

--- a/test/valid/test_definitions_integer_enum.py
+++ b/test/valid/test_definitions_integer_enum.py
@@ -10,6 +10,10 @@ class ABcd(enum.Enum):
     C = 2
     D = 3
 
+    @staticmethod
+    def from_dict(d):
+        return ABcd(d)
+
     def as_dict(self):
         return self.value
 
@@ -21,8 +25,13 @@ class RootObject:
     def __init__(self):
         pass
 
+    @staticmethod
+    def from_dict(d):
+        v = {}
+        return RootObject(**v)
+
     def as_dict(self):
-        d = dict()
+        d = {}
         return d
 
     def __repr__(self):

--- a/test/valid/test_definitions_nested_objects.py
+++ b/test/valid/test_definitions_nested_objects.py
@@ -40,8 +40,32 @@ class ABcd:
 
             ListVal = property(_get_ListVal, _set_ListVal)
 
+            @staticmethod
+            def from_dict(d):
+                v = {}
+                if "IntVal" in d:
+                    if not isinstance(d["IntVal"], int):
+                        raise TypeError("IntVal must be int")
+
+                    v["IntVal"] = (
+                        int.from_dict(d["IntVal"])
+                        if hasattr(int, "from_dict")
+                        else d["IntVal"]
+                    )
+                if "ListVal" in d:
+                    if not isinstance(d["ListVal"], list):
+                        raise TypeError("ListVal must be list")
+                    if not all(isinstance(i, str) for i in d["ListVal"]):
+                        raise TypeError("ListVal list values must be str")
+
+                    v["ListVal"] = [
+                        str.from_dict(p) if hasattr(str, "from_dict") else p
+                        for p in d["ListVal"]
+                    ]
+                return ABcd._Child1._Child2(**v)
+
             def as_dict(self):
-                d = dict()
+                d = {}
                 if self.__IntVal is not None:
                     d["IntVal"] = (
                         self.__IntVal.as_dict()
@@ -87,14 +111,37 @@ class ABcd:
 
         def _set_Child2(self, value):
             if not isinstance(value, ABcd._Child1._Child2):
-                raise TypeError("Child2 must be _Child2")
+                raise TypeError("Child2 must be ABcd._Child1._Child2")
 
             self.__Child2 = value
 
         Child2 = property(_get_Child2, _set_Child2)
 
+        @staticmethod
+        def from_dict(d):
+            v = {}
+            if "IntVal" in d:
+                if not isinstance(d["IntVal"], int):
+                    raise TypeError("IntVal must be int")
+
+                v["IntVal"] = (
+                    int.from_dict(d["IntVal"])
+                    if hasattr(int, "from_dict")
+                    else d["IntVal"]
+                )
+            if "Child2" in d:
+                if not isinstance(d["Child2"], ABcd._Child1._Child2):
+                    raise TypeError("Child2 must be ABcd._Child1._Child2")
+
+                v["Child2"] = (
+                    ABcd._Child1._Child2.from_dict(d["Child2"])
+                    if hasattr(ABcd._Child1._Child2, "from_dict")
+                    else d["Child2"]
+                )
+            return ABcd._Child1(**v)
+
         def as_dict(self):
-            d = dict()
+            d = {}
             if self.__IntVal is not None:
                 d["IntVal"] = (
                     self.__IntVal.as_dict()
@@ -126,14 +173,28 @@ class ABcd:
 
     def _set_Child1(self, value):
         if not isinstance(value, ABcd._Child1):
-            raise TypeError("Child1 must be _Child1")
+            raise TypeError("Child1 must be ABcd._Child1")
 
         self.__Child1 = value
 
     Child1 = property(_get_Child1, _set_Child1)
 
+    @staticmethod
+    def from_dict(d):
+        v = {}
+        if "Child1" in d:
+            if not isinstance(d["Child1"], ABcd._Child1):
+                raise TypeError("Child1 must be ABcd._Child1")
+
+            v["Child1"] = (
+                ABcd._Child1.from_dict(d["Child1"])
+                if hasattr(ABcd._Child1, "from_dict")
+                else d["Child1"]
+            )
+        return ABcd(**v)
+
     def as_dict(self):
-        d = dict()
+        d = {}
         if self.__Child1 is not None:
             d["Child1"] = (
                 self.__Child1.as_dict()
@@ -150,8 +211,13 @@ class RootObject:
     def __init__(self):
         pass
 
+    @staticmethod
+    def from_dict(d):
+        v = {}
+        return RootObject(**v)
+
     def as_dict(self):
-        d = dict()
+        d = {}
         return d
 
     def __repr__(self):

--- a/test/valid/test_definitions_nested_objects.py
+++ b/test/valid/test_definitions_nested_objects.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env/python
+
+
+class ABcd:
+    class _Child1:
+        class _Child2:
+
+            _types_map = {
+                "IntVal": {"type": int, "subtype": None},
+                "ListVal": {"type": list, "subtype": str},
+            }
+            _formats_map = {}
+
+            def __init__(self, IntVal=None, ListVal=None):
+                pass
+                self.__IntVal = IntVal
+                self.__ListVal = ListVal
+
+            def _get_IntVal(self):
+                return self.__IntVal
+
+            def _set_IntVal(self, value):
+                if not isinstance(value, int):
+                    raise TypeError("IntVal must be int")
+
+                self.__IntVal = value
+
+            IntVal = property(_get_IntVal, _set_IntVal)
+
+            def _get_ListVal(self):
+                return self.__ListVal
+
+            def _set_ListVal(self, value):
+                if not isinstance(value, list):
+                    raise TypeError("ListVal must be list")
+                if not all(isinstance(i, str) for i in value):
+                    raise TypeError("ListVal list values must be str")
+
+                self.__ListVal = value
+
+            ListVal = property(_get_ListVal, _set_ListVal)
+
+            def as_dict(self):
+                d = dict()
+                if self.__IntVal is not None:
+                    d["IntVal"] = (
+                        self.__IntVal.as_dict()
+                        if hasattr(self.__IntVal, "as_dict")
+                        else self.__IntVal
+                    )
+                if self.__ListVal is not None:
+                    d["ListVal"] = [
+                        p.as_dict() if hasattr(p, "as_dict") else p
+                        for p in self.__ListVal
+                    ]
+                return d
+
+            def __repr__(self):
+                return "<Class _Child2. IntVal: {}, ListVal: {}>".format(
+                    self.__IntVal, self.__ListVal
+                )
+
+        _types_map = {
+            "IntVal": {"type": int, "subtype": None},
+            "Child2": {"type": _Child2, "subtype": None},
+        }
+        _formats_map = {}
+
+        def __init__(self, IntVal=None, Child2=None):
+            pass
+            self.__IntVal = IntVal
+            self.__Child2 = Child2
+
+        def _get_IntVal(self):
+            return self.__IntVal
+
+        def _set_IntVal(self, value):
+            if not isinstance(value, int):
+                raise TypeError("IntVal must be int")
+
+            self.__IntVal = value
+
+        IntVal = property(_get_IntVal, _set_IntVal)
+
+        def _get_Child2(self):
+            return self.__Child2
+
+        def _set_Child2(self, value):
+            if not isinstance(value, ABcd._Child1._Child2):
+                raise TypeError("Child2 must be _Child2")
+
+            self.__Child2 = value
+
+        Child2 = property(_get_Child2, _set_Child2)
+
+        def as_dict(self):
+            d = dict()
+            if self.__IntVal is not None:
+                d["IntVal"] = (
+                    self.__IntVal.as_dict()
+                    if hasattr(self.__IntVal, "as_dict")
+                    else self.__IntVal
+                )
+            if self.__Child2 is not None:
+                d["Child2"] = (
+                    self.__Child2.as_dict()
+                    if hasattr(self.__Child2, "as_dict")
+                    else self.__Child2
+                )
+            return d
+
+        def __repr__(self):
+            return "<Class _Child1. IntVal: {}, Child2: {}>".format(
+                self.__IntVal, self.__Child2
+            )
+
+    _types_map = {"Child1": {"type": _Child1, "subtype": None}}
+    _formats_map = {}
+
+    def __init__(self, Child1=None):
+        pass
+        self.__Child1 = Child1
+
+    def _get_Child1(self):
+        return self.__Child1
+
+    def _set_Child1(self, value):
+        if not isinstance(value, ABcd._Child1):
+            raise TypeError("Child1 must be _Child1")
+
+        self.__Child1 = value
+
+    Child1 = property(_get_Child1, _set_Child1)
+
+    def as_dict(self):
+        d = dict()
+        if self.__Child1 is not None:
+            d["Child1"] = (
+                self.__Child1.as_dict()
+                if hasattr(self.__Child1, "as_dict")
+                else self.__Child1
+            )
+        return d
+
+    def __repr__(self):
+        return "<Class ABcd. Child1: {}>".format(self.__Child1)
+
+
+class RootObject:
+    def __init__(self):
+        pass
+
+    def as_dict(self):
+        d = dict()
+        return d
+
+    def __repr__(self):
+        return "<Class RootObject. >".format()

--- a/test/valid/test_definitions_string_enum.py
+++ b/test/valid/test_definitions_string_enum.py
@@ -9,6 +9,10 @@ class ABcd(enum.Enum):
     B = "B"
     C = "C"
 
+    @staticmethod
+    def from_dict(d):
+        return ABcd(d)
+
     def as_dict(self):
         return self.value
 
@@ -20,8 +24,13 @@ class RootObject:
     def __init__(self):
         pass
 
+    @staticmethod
+    def from_dict(d):
+        v = {}
+        return RootObject(**v)
+
     def as_dict(self):
-        d = dict()
+        d = {}
         return d
 
     def __repr__(self):

--- a/test/valid/test_definitions_string_enum.py
+++ b/test/valid/test_definitions_string_enum.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env/python
+
+import enum
+
+
+class ABcd(enum.Enum):
+
+    A = "A"
+    B = "B"
+    C = "C"
+
+    def as_dict(self):
+        return self.value
+
+    def __repr__(self):
+        return "<Enum ABcd. {}: {}>".format(self.name, self.value)
+
+
+class RootObject:
+    def __init__(self):
+        pass
+
+    def as_dict(self):
+        d = dict()
+        return d
+
+    def __repr__(self):
+        return "<Class RootObject. >".format()

--- a/test/valid/test_definitions_with_nested_refs.py
+++ b/test/valid/test_definitions_with_nested_refs.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env/python
+
+
+class ABcd:
+    class _Child1:
+        class _Child2:
+
+            _types_map = {
+                "IntVal": {"type": int, "subtype": None},
+                "ListVal": {"type": list, "subtype": str},
+            }
+            _formats_map = {}
+
+            def __init__(self, IntVal=None, ListVal=None):
+                pass
+                self.__IntVal = IntVal
+                self.__ListVal = ListVal
+
+            def _get_IntVal(self):
+                return self.__IntVal
+
+            def _set_IntVal(self, value):
+                if not isinstance(value, int):
+                    raise TypeError("IntVal must be int")
+
+                self.__IntVal = value
+
+            IntVal = property(_get_IntVal, _set_IntVal)
+
+            def _get_ListVal(self):
+                return self.__ListVal
+
+            def _set_ListVal(self, value):
+                if not isinstance(value, list):
+                    raise TypeError("ListVal must be list")
+                if not all(isinstance(i, str) for i in value):
+                    raise TypeError("ListVal list values must be str")
+
+                self.__ListVal = value
+
+            ListVal = property(_get_ListVal, _set_ListVal)
+
+            def as_dict(self):
+                d = dict()
+                if self.__IntVal is not None:
+                    d["IntVal"] = (
+                        self.__IntVal.as_dict()
+                        if hasattr(self.__IntVal, "as_dict")
+                        else self.__IntVal
+                    )
+                if self.__ListVal is not None:
+                    d["ListVal"] = [
+                        p.as_dict() if hasattr(p, "as_dict") else p
+                        for p in self.__ListVal
+                    ]
+                return d
+
+            def __repr__(self):
+                return "<Class _Child2. IntVal: {}, ListVal: {}>".format(
+                    self.__IntVal, self.__ListVal
+                )
+
+        _types_map = {
+            "IntVal": {"type": int, "subtype": None},
+            "Child2": {"type": _Child2, "subtype": None},
+        }
+        _formats_map = {}
+
+        def __init__(self, IntVal=None, Child2=None):
+            pass
+            self.__IntVal = IntVal
+            self.__Child2 = Child2
+
+        def _get_IntVal(self):
+            return self.__IntVal
+
+        def _set_IntVal(self, value):
+            if not isinstance(value, int):
+                raise TypeError("IntVal must be int")
+
+            self.__IntVal = value
+
+        IntVal = property(_get_IntVal, _set_IntVal)
+
+        def _get_Child2(self):
+            return self.__Child2
+
+        def _set_Child2(self, value):
+            if not isinstance(value, ABcd._Child1._Child2):
+                raise TypeError("Child2 must be _Child2")
+
+            self.__Child2 = value
+
+        Child2 = property(_get_Child2, _set_Child2)
+
+        def as_dict(self):
+            d = dict()
+            if self.__IntVal is not None:
+                d["IntVal"] = (
+                    self.__IntVal.as_dict()
+                    if hasattr(self.__IntVal, "as_dict")
+                    else self.__IntVal
+                )
+            if self.__Child2 is not None:
+                d["Child2"] = (
+                    self.__Child2.as_dict()
+                    if hasattr(self.__Child2, "as_dict")
+                    else self.__Child2
+                )
+            return d
+
+        def __repr__(self):
+            return "<Class _Child1. IntVal: {}, Child2: {}>".format(
+                self.__IntVal, self.__Child2
+            )
+
+    _types_map = {"Child1": {"type": _Child1, "subtype": None}}
+    _formats_map = {}
+
+    def __init__(self, Child1=None):
+        pass
+        self.__Child1 = Child1
+
+    def _get_Child1(self):
+        return self.__Child1
+
+    def _set_Child1(self, value):
+        if not isinstance(value, ABcd._Child1):
+            raise TypeError("Child1 must be _Child1")
+
+        self.__Child1 = value
+
+    Child1 = property(_get_Child1, _set_Child1)
+
+    def as_dict(self):
+        d = dict()
+        if self.__Child1 is not None:
+            d["Child1"] = (
+                self.__Child1.as_dict()
+                if hasattr(self.__Child1, "as_dict")
+                else self.__Child1
+            )
+        return d
+
+    def __repr__(self):
+        return "<Class ABcd. Child1: {}>".format(self.__Child1)
+
+
+class Ref:
+
+    _types_map = {
+        "IntVal": {"type": int, "subtype": None},
+        "ListVal": {"type": list, "subtype": str},
+    }
+    _formats_map = {}
+
+    def __init__(self, IntVal=None, ListVal=None):
+        pass
+        self.__IntVal = IntVal
+        self.__ListVal = ListVal
+
+    def _get_IntVal(self):
+        return self.__IntVal
+
+    def _set_IntVal(self, value):
+        if not isinstance(value, int):
+            raise TypeError("IntVal must be int")
+
+        self.__IntVal = value
+
+    IntVal = property(_get_IntVal, _set_IntVal)
+
+    def _get_ListVal(self):
+        return self.__ListVal
+
+    def _set_ListVal(self, value):
+        if not isinstance(value, list):
+            raise TypeError("ListVal must be list")
+        if not all(isinstance(i, str) for i in value):
+            raise TypeError("ListVal list values must be str")
+
+        self.__ListVal = value
+
+    ListVal = property(_get_ListVal, _set_ListVal)
+
+    def as_dict(self):
+        d = dict()
+        if self.__IntVal is not None:
+            d["IntVal"] = (
+                self.__IntVal.as_dict()
+                if hasattr(self.__IntVal, "as_dict")
+                else self.__IntVal
+            )
+        if self.__ListVal is not None:
+            d["ListVal"] = [
+                p.as_dict() if hasattr(p, "as_dict") else p for p in self.__ListVal
+            ]
+        return d
+
+    def __repr__(self):
+        return "<Class Ref. IntVal: {}, ListVal: {}>".format(
+            self.__IntVal, self.__ListVal
+        )
+
+
+class AAAA:
+
+    _types_map = {
+        "X": {"type": int, "subtype": None},
+        "YRef": {"type": ABcd._Child1._Child2, "subtype": None},
+    }
+    _formats_map = {}
+
+    def __init__(self, X=None, YRef=None):
+        pass
+        self.__X = X
+        self.__YRef = YRef
+
+    def _get_X(self):
+        return self.__X
+
+    def _set_X(self, value):
+        if not isinstance(value, int):
+            raise TypeError("X must be int")
+
+        self.__X = value
+
+    X = property(_get_X, _set_X)
+
+    def _get_YRef(self):
+        return self.__YRef
+
+    def _set_YRef(self, value):
+        if not isinstance(value, ABcd._Child1._Child2):
+            raise TypeError("YRef must be ABcd._Child1._Child2")
+
+        self.__YRef = value
+
+    YRef = property(_get_YRef, _set_YRef)
+
+    def as_dict(self):
+        d = dict()
+        if self.__X is not None:
+            d["X"] = self.__X.as_dict() if hasattr(self.__X, "as_dict") else self.__X
+        if self.__YRef is not None:
+            d["YRef"] = (
+                self.__YRef.as_dict()
+                if hasattr(self.__YRef, "as_dict")
+                else self.__YRef
+            )
+        return d
+
+    def __repr__(self):
+        return "<Class AAAA. X: {}, YRef: {}>".format(self.__X, self.__YRef)
+
+
+class RootObject:
+    def __init__(self):
+        pass
+
+    def as_dict(self):
+        d = dict()
+        return d
+
+    def __repr__(self):
+        return "<Class RootObject. >".format()

--- a/test/valid/test_definitions_with_nested_refs.py
+++ b/test/valid/test_definitions_with_nested_refs.py
@@ -40,8 +40,32 @@ class ABcd:
 
             ListVal = property(_get_ListVal, _set_ListVal)
 
+            @staticmethod
+            def from_dict(d):
+                v = {}
+                if "IntVal" in d:
+                    if not isinstance(d["IntVal"], int):
+                        raise TypeError("IntVal must be int")
+
+                    v["IntVal"] = (
+                        int.from_dict(d["IntVal"])
+                        if hasattr(int, "from_dict")
+                        else d["IntVal"]
+                    )
+                if "ListVal" in d:
+                    if not isinstance(d["ListVal"], list):
+                        raise TypeError("ListVal must be list")
+                    if not all(isinstance(i, str) for i in d["ListVal"]):
+                        raise TypeError("ListVal list values must be str")
+
+                    v["ListVal"] = [
+                        str.from_dict(p) if hasattr(str, "from_dict") else p
+                        for p in d["ListVal"]
+                    ]
+                return ABcd._Child1._Child2(**v)
+
             def as_dict(self):
-                d = dict()
+                d = {}
                 if self.__IntVal is not None:
                     d["IntVal"] = (
                         self.__IntVal.as_dict()
@@ -87,14 +111,37 @@ class ABcd:
 
         def _set_Child2(self, value):
             if not isinstance(value, ABcd._Child1._Child2):
-                raise TypeError("Child2 must be _Child2")
+                raise TypeError("Child2 must be ABcd._Child1._Child2")
 
             self.__Child2 = value
 
         Child2 = property(_get_Child2, _set_Child2)
 
+        @staticmethod
+        def from_dict(d):
+            v = {}
+            if "IntVal" in d:
+                if not isinstance(d["IntVal"], int):
+                    raise TypeError("IntVal must be int")
+
+                v["IntVal"] = (
+                    int.from_dict(d["IntVal"])
+                    if hasattr(int, "from_dict")
+                    else d["IntVal"]
+                )
+            if "Child2" in d:
+                if not isinstance(d["Child2"], ABcd._Child1._Child2):
+                    raise TypeError("Child2 must be ABcd._Child1._Child2")
+
+                v["Child2"] = (
+                    ABcd._Child1._Child2.from_dict(d["Child2"])
+                    if hasattr(ABcd._Child1._Child2, "from_dict")
+                    else d["Child2"]
+                )
+            return ABcd._Child1(**v)
+
         def as_dict(self):
-            d = dict()
+            d = {}
             if self.__IntVal is not None:
                 d["IntVal"] = (
                     self.__IntVal.as_dict()
@@ -126,14 +173,28 @@ class ABcd:
 
     def _set_Child1(self, value):
         if not isinstance(value, ABcd._Child1):
-            raise TypeError("Child1 must be _Child1")
+            raise TypeError("Child1 must be ABcd._Child1")
 
         self.__Child1 = value
 
     Child1 = property(_get_Child1, _set_Child1)
 
+    @staticmethod
+    def from_dict(d):
+        v = {}
+        if "Child1" in d:
+            if not isinstance(d["Child1"], ABcd._Child1):
+                raise TypeError("Child1 must be ABcd._Child1")
+
+            v["Child1"] = (
+                ABcd._Child1.from_dict(d["Child1"])
+                if hasattr(ABcd._Child1, "from_dict")
+                else d["Child1"]
+            )
+        return ABcd(**v)
+
     def as_dict(self):
-        d = dict()
+        d = {}
         if self.__Child1 is not None:
             d["Child1"] = (
                 self.__Child1.as_dict()
@@ -183,8 +244,30 @@ class Ref:
 
     ListVal = property(_get_ListVal, _set_ListVal)
 
+    @staticmethod
+    def from_dict(d):
+        v = {}
+        if "IntVal" in d:
+            if not isinstance(d["IntVal"], int):
+                raise TypeError("IntVal must be int")
+
+            v["IntVal"] = (
+                int.from_dict(d["IntVal"]) if hasattr(int, "from_dict") else d["IntVal"]
+            )
+        if "ListVal" in d:
+            if not isinstance(d["ListVal"], list):
+                raise TypeError("ListVal must be list")
+            if not all(isinstance(i, str) for i in d["ListVal"]):
+                raise TypeError("ListVal list values must be str")
+
+            v["ListVal"] = [
+                str.from_dict(p) if hasattr(str, "from_dict") else p
+                for p in d["ListVal"]
+            ]
+        return ABcd._Child1._Child2(**v)
+
     def as_dict(self):
-        d = dict()
+        d = {}
         if self.__IntVal is not None:
             d["IntVal"] = (
                 self.__IntVal.as_dict()
@@ -238,8 +321,27 @@ class AAAA:
 
     YRef = property(_get_YRef, _set_YRef)
 
+    @staticmethod
+    def from_dict(d):
+        v = {}
+        if "X" in d:
+            if not isinstance(d["X"], int):
+                raise TypeError("X must be int")
+
+            v["X"] = int.from_dict(d["X"]) if hasattr(int, "from_dict") else d["X"]
+        if "YRef" in d:
+            if not isinstance(d["YRef"], ABcd._Child1._Child2):
+                raise TypeError("YRef must be ABcd._Child1._Child2")
+
+            v["YRef"] = (
+                ABcd._Child1._Child2.from_dict(d["YRef"])
+                if hasattr(ABcd._Child1._Child2, "from_dict")
+                else d["YRef"]
+            )
+        return AAAA(**v)
+
     def as_dict(self):
-        d = dict()
+        d = {}
         if self.__X is not None:
             d["X"] = self.__X.as_dict() if hasattr(self.__X, "as_dict") else self.__X
         if self.__YRef is not None:
@@ -258,8 +360,13 @@ class RootObject:
     def __init__(self):
         pass
 
+    @staticmethod
+    def from_dict(d):
+        v = {}
+        return RootObject(**v)
+
     def as_dict(self):
-        d = dict()
+        d = {}
         return d
 
     def __repr__(self):

--- a/test/valid/test_definitions_with_refs.py
+++ b/test/valid/test_definitions_with_refs.py
@@ -36,8 +36,27 @@ class ABcd:
 
     Child2 = property(_get_Child2, _set_Child2)
 
+    @staticmethod
+    def from_dict(d):
+        v = {}
+        if "Child1" in d:
+            if not isinstance(d["Child1"], int):
+                raise TypeError("Child1 must be int")
+
+            v["Child1"] = (
+                int.from_dict(d["Child1"]) if hasattr(int, "from_dict") else d["Child1"]
+            )
+        if "Child2" in d:
+            if not isinstance(d["Child2"], str):
+                raise TypeError("Child2 must be str")
+
+            v["Child2"] = (
+                str.from_dict(d["Child2"]) if hasattr(str, "from_dict") else d["Child2"]
+            )
+        return ABcd(**v)
+
     def as_dict(self):
-        d = dict()
+        d = {}
         if self.__Child1 is not None:
             d["Child1"] = (
                 self.__Child1.as_dict()
@@ -78,8 +97,22 @@ class SubRef:
 
     ChildA = property(_get_ChildA, _set_ChildA)
 
+    @staticmethod
+    def from_dict(d):
+        v = {}
+        if "ChildA" in d:
+            if not isinstance(d["ChildA"], ABcd):
+                raise TypeError("ChildA must be ABcd")
+
+            v["ChildA"] = (
+                ABcd.from_dict(d["ChildA"])
+                if hasattr(ABcd, "from_dict")
+                else d["ChildA"]
+            )
+        return SubRef(**v)
+
     def as_dict(self):
-        d = dict()
+        d = {}
         if self.__ChildA is not None:
             d["ChildA"] = (
                 self.__ChildA.as_dict()
@@ -127,8 +160,27 @@ class DirectRef:
 
     Child2 = property(_get_Child2, _set_Child2)
 
+    @staticmethod
+    def from_dict(d):
+        v = {}
+        if "Child1" in d:
+            if not isinstance(d["Child1"], int):
+                raise TypeError("Child1 must be int")
+
+            v["Child1"] = (
+                int.from_dict(d["Child1"]) if hasattr(int, "from_dict") else d["Child1"]
+            )
+        if "Child2" in d:
+            if not isinstance(d["Child2"], str):
+                raise TypeError("Child2 must be str")
+
+            v["Child2"] = (
+                str.from_dict(d["Child2"]) if hasattr(str, "from_dict") else d["Child2"]
+            )
+        return DirectRef(**v)
+
     def as_dict(self):
-        d = dict()
+        d = {}
         if self.__Child1 is not None:
             d["Child1"] = (
                 self.__Child1.as_dict()
@@ -153,8 +205,13 @@ class RootObject:
     def __init__(self):
         pass
 
+    @staticmethod
+    def from_dict(d):
+        v = {}
+        return RootObject(**v)
+
     def as_dict(self):
-        d = dict()
+        d = {}
         return d
 
     def __repr__(self):

--- a/test/valid/test_definitions_with_refs.py
+++ b/test/valid/test_definitions_with_refs.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env/python
+
+
+class ABcd:
+
+    _types_map = {
+        "Child1": {"type": int, "subtype": None},
+        "Child2": {"type": str, "subtype": None},
+    }
+    _formats_map = {}
+
+    def __init__(self, Child1=None, Child2=None):
+        pass
+        self.__Child1 = Child1
+        self.__Child2 = Child2
+
+    def _get_Child1(self):
+        return self.__Child1
+
+    def _set_Child1(self, value):
+        if not isinstance(value, int):
+            raise TypeError("Child1 must be int")
+
+        self.__Child1 = value
+
+    Child1 = property(_get_Child1, _set_Child1)
+
+    def _get_Child2(self):
+        return self.__Child2
+
+    def _set_Child2(self, value):
+        if not isinstance(value, str):
+            raise TypeError("Child2 must be str")
+
+        self.__Child2 = value
+
+    Child2 = property(_get_Child2, _set_Child2)
+
+    def as_dict(self):
+        d = dict()
+        if self.__Child1 is not None:
+            d["Child1"] = (
+                self.__Child1.as_dict()
+                if hasattr(self.__Child1, "as_dict")
+                else self.__Child1
+            )
+        if self.__Child2 is not None:
+            d["Child2"] = (
+                self.__Child2.as_dict()
+                if hasattr(self.__Child2, "as_dict")
+                else self.__Child2
+            )
+        return d
+
+    def __repr__(self):
+        return "<Class ABcd. Child1: {}, Child2: {}>".format(
+            self.__Child1, self.__Child2
+        )
+
+
+class SubRef:
+
+    _types_map = {"ChildA": {"type": ABcd, "subtype": None}}
+    _formats_map = {}
+
+    def __init__(self, ChildA=None):
+        pass
+        self.__ChildA = ChildA
+
+    def _get_ChildA(self):
+        return self.__ChildA
+
+    def _set_ChildA(self, value):
+        if not isinstance(value, ABcd):
+            raise TypeError("ChildA must be ABcd")
+
+        self.__ChildA = value
+
+    ChildA = property(_get_ChildA, _set_ChildA)
+
+    def as_dict(self):
+        d = dict()
+        if self.__ChildA is not None:
+            d["ChildA"] = (
+                self.__ChildA.as_dict()
+                if hasattr(self.__ChildA, "as_dict")
+                else self.__ChildA
+            )
+        return d
+
+    def __repr__(self):
+        return "<Class SubRef. ChildA: {}>".format(self.__ChildA)
+
+
+class DirectRef:
+
+    _types_map = {
+        "Child1": {"type": int, "subtype": None},
+        "Child2": {"type": str, "subtype": None},
+    }
+    _formats_map = {}
+
+    def __init__(self, Child1=None, Child2=None):
+        pass
+        self.__Child1 = Child1
+        self.__Child2 = Child2
+
+    def _get_Child1(self):
+        return self.__Child1
+
+    def _set_Child1(self, value):
+        if not isinstance(value, int):
+            raise TypeError("Child1 must be int")
+
+        self.__Child1 = value
+
+    Child1 = property(_get_Child1, _set_Child1)
+
+    def _get_Child2(self):
+        return self.__Child2
+
+    def _set_Child2(self, value):
+        if not isinstance(value, str):
+            raise TypeError("Child2 must be str")
+
+        self.__Child2 = value
+
+    Child2 = property(_get_Child2, _set_Child2)
+
+    def as_dict(self):
+        d = dict()
+        if self.__Child1 is not None:
+            d["Child1"] = (
+                self.__Child1.as_dict()
+                if hasattr(self.__Child1, "as_dict")
+                else self.__Child1
+            )
+        if self.__Child2 is not None:
+            d["Child2"] = (
+                self.__Child2.as_dict()
+                if hasattr(self.__Child2, "as_dict")
+                else self.__Child2
+            )
+        return d
+
+    def __repr__(self):
+        return "<Class DirectRef. Child1: {}, Child2: {}>".format(
+            self.__Child1, self.__Child2
+        )
+
+
+class RootObject:
+    def __init__(self):
+        pass
+
+    def as_dict(self):
+        d = dict()
+        return d
+
+    def __repr__(self):
+        return "<Class RootObject. >".format()

--- a/test/valid/test_root_basic_generation.py
+++ b/test/valid/test_root_basic_generation.py
@@ -6,8 +6,13 @@ class Abcd:
         def __init__(self):
             pass
 
+        @staticmethod
+        def from_dict(d):
+            v = {}
+            return Abcd._Object(**v)
+
         def as_dict(self):
-            d = dict()
+            d = {}
             return d
 
         def __repr__(self):
@@ -81,14 +86,61 @@ class Abcd:
 
     def _set_Object(self, value):
         if not isinstance(value, Abcd._Object):
-            raise TypeError("Object must be _Object")
+            raise TypeError("Object must be Abcd._Object")
 
         self.__Object = value
 
     Object = property(_get_Object, _set_Object)
 
+    @staticmethod
+    def from_dict(d):
+        v = {}
+        if "Int" in d:
+            if not isinstance(d["Int"], int):
+                raise TypeError("Int must be int")
+
+            v["Int"] = (
+                int.from_dict(d["Int"]) if hasattr(int, "from_dict") else d["Int"]
+            )
+        if "Float" in d:
+            if not isinstance(d["Float"], float):
+                raise TypeError("Float must be float")
+
+            v["Float"] = (
+                float.from_dict(d["Float"])
+                if hasattr(float, "from_dict")
+                else d["Float"]
+            )
+        if "ListInt" in d:
+            if not isinstance(d["ListInt"], list):
+                raise TypeError("ListInt must be list")
+            if not all(isinstance(i, int) for i in d["ListInt"]):
+                raise TypeError("ListInt list values must be int")
+
+            v["ListInt"] = [
+                int.from_dict(p) if hasattr(int, "from_dict") else p
+                for p in d["ListInt"]
+            ]
+        if "String" in d:
+            if not isinstance(d["String"], str):
+                raise TypeError("String must be str")
+
+            v["String"] = (
+                str.from_dict(d["String"]) if hasattr(str, "from_dict") else d["String"]
+            )
+        if "Object" in d:
+            if not isinstance(d["Object"], Abcd._Object):
+                raise TypeError("Object must be Abcd._Object")
+
+            v["Object"] = (
+                Abcd._Object.from_dict(d["Object"])
+                if hasattr(Abcd._Object, "from_dict")
+                else d["Object"]
+            )
+        return Abcd(**v)
+
     def as_dict(self):
-        d = dict()
+        d = {}
         if self.__Int is not None:
             d["Int"] = (
                 self.__Int.as_dict() if hasattr(self.__Int, "as_dict") else self.__Int

--- a/test/valid/test_root_basic_generation.py
+++ b/test/valid/test_root_basic_generation.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env/python
+
+
+class Abcd:
+    class _Object:
+        def __init__(self):
+            pass
+
+        def as_dict(self):
+            d = dict()
+            return d
+
+        def __repr__(self):
+            return "<Class _Object. >".format()
+
+    _types_map = {
+        "Int": {"type": int, "subtype": None},
+        "Float": {"type": float, "subtype": None},
+        "ListInt": {"type": list, "subtype": int},
+        "String": {"type": str, "subtype": None},
+        "Object": {"type": _Object, "subtype": None},
+    }
+    _formats_map = {}
+
+    def __init__(self, Int=None, Float=None, ListInt=None, String=None, Object=None):
+        pass
+        self.__Int = Int
+        self.__Float = Float
+        self.__ListInt = ListInt
+        self.__String = String
+        self.__Object = Object
+
+    def _get_Int(self):
+        return self.__Int
+
+    def _set_Int(self, value):
+        if not isinstance(value, int):
+            raise TypeError("Int must be int")
+
+        self.__Int = value
+
+    Int = property(_get_Int, _set_Int)
+
+    def _get_Float(self):
+        return self.__Float
+
+    def _set_Float(self, value):
+        if not isinstance(value, float):
+            raise TypeError("Float must be float")
+
+        self.__Float = value
+
+    Float = property(_get_Float, _set_Float)
+
+    def _get_ListInt(self):
+        return self.__ListInt
+
+    def _set_ListInt(self, value):
+        if not isinstance(value, list):
+            raise TypeError("ListInt must be list")
+        if not all(isinstance(i, int) for i in value):
+            raise TypeError("ListInt list values must be int")
+
+        self.__ListInt = value
+
+    ListInt = property(_get_ListInt, _set_ListInt)
+
+    def _get_String(self):
+        return self.__String
+
+    def _set_String(self, value):
+        if not isinstance(value, str):
+            raise TypeError("String must be str")
+
+        self.__String = value
+
+    String = property(_get_String, _set_String)
+
+    def _get_Object(self):
+        return self.__Object
+
+    def _set_Object(self, value):
+        if not isinstance(value, Abcd._Object):
+            raise TypeError("Object must be _Object")
+
+        self.__Object = value
+
+    Object = property(_get_Object, _set_Object)
+
+    def as_dict(self):
+        d = dict()
+        if self.__Int is not None:
+            d["Int"] = (
+                self.__Int.as_dict() if hasattr(self.__Int, "as_dict") else self.__Int
+            )
+        if self.__Float is not None:
+            d["Float"] = (
+                self.__Float.as_dict()
+                if hasattr(self.__Float, "as_dict")
+                else self.__Float
+            )
+        if self.__ListInt is not None:
+            d["ListInt"] = [
+                p.as_dict() if hasattr(p, "as_dict") else p for p in self.__ListInt
+            ]
+        if self.__String is not None:
+            d["String"] = (
+                self.__String.as_dict()
+                if hasattr(self.__String, "as_dict")
+                else self.__String
+            )
+        if self.__Object is not None:
+            d["Object"] = (
+                self.__Object.as_dict()
+                if hasattr(self.__Object, "as_dict")
+                else self.__Object
+            )
+        return d
+
+    def __repr__(self):
+        return "<Class Abcd. Int: {}, Float: {}, ListInt: {}, String: {}, Object: {}>".format(
+            self.__Int, self.__Float, self.__ListInt, self.__String, self.__Object
+        )

--- a/test/valid/test_root_integer_enum.py
+++ b/test/valid/test_root_integer_enum.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env/python
+
+import enum
+
+
+class Abcd(enum.Enum):
+
+    A = 0
+    B = 1
+    C = 2
+    D = 3
+
+    def as_dict(self):
+        return self.value
+
+    def __repr__(self):
+        return "<Enum Abcd. {}: {}>".format(self.name, self.value)

--- a/test/valid/test_root_integer_enum.py
+++ b/test/valid/test_root_integer_enum.py
@@ -10,6 +10,10 @@ class Abcd(enum.Enum):
     C = 2
     D = 3
 
+    @staticmethod
+    def from_dict(d):
+        return Abcd(d)
+
     def as_dict(self):
         return self.value
 

--- a/test/valid/test_root_nested_objects.py
+++ b/test/valid/test_root_nested_objects.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env/python
+
+
+class Abcd:
+    class _Child1:
+        class _Child2:
+
+            _types_map = {
+                "IntVal": {"type": int, "subtype": None},
+                "ListVal": {"type": list, "subtype": str},
+            }
+            _formats_map = {}
+
+            def __init__(self, IntVal=None, ListVal=None):
+                pass
+                self.__IntVal = IntVal
+                self.__ListVal = ListVal
+
+            def _get_IntVal(self):
+                return self.__IntVal
+
+            def _set_IntVal(self, value):
+                if not isinstance(value, int):
+                    raise TypeError("IntVal must be int")
+
+                self.__IntVal = value
+
+            IntVal = property(_get_IntVal, _set_IntVal)
+
+            def _get_ListVal(self):
+                return self.__ListVal
+
+            def _set_ListVal(self, value):
+                if not isinstance(value, list):
+                    raise TypeError("ListVal must be list")
+                if not all(isinstance(i, str) for i in value):
+                    raise TypeError("ListVal list values must be str")
+
+                self.__ListVal = value
+
+            ListVal = property(_get_ListVal, _set_ListVal)
+
+            def as_dict(self):
+                d = dict()
+                if self.__IntVal is not None:
+                    d["IntVal"] = (
+                        self.__IntVal.as_dict()
+                        if hasattr(self.__IntVal, "as_dict")
+                        else self.__IntVal
+                    )
+                if self.__ListVal is not None:
+                    d["ListVal"] = [
+                        p.as_dict() if hasattr(p, "as_dict") else p
+                        for p in self.__ListVal
+                    ]
+                return d
+
+            def __repr__(self):
+                return "<Class _Child2. IntVal: {}, ListVal: {}>".format(
+                    self.__IntVal, self.__ListVal
+                )
+
+        _types_map = {
+            "IntVal": {"type": int, "subtype": None},
+            "Child2": {"type": _Child2, "subtype": None},
+        }
+        _formats_map = {}
+
+        def __init__(self, IntVal=None, Child2=None):
+            pass
+            self.__IntVal = IntVal
+            self.__Child2 = Child2
+
+        def _get_IntVal(self):
+            return self.__IntVal
+
+        def _set_IntVal(self, value):
+            if not isinstance(value, int):
+                raise TypeError("IntVal must be int")
+
+            self.__IntVal = value
+
+        IntVal = property(_get_IntVal, _set_IntVal)
+
+        def _get_Child2(self):
+            return self.__Child2
+
+        def _set_Child2(self, value):
+            if not isinstance(value, Abcd._Child1._Child2):
+                raise TypeError("Child2 must be _Child2")
+
+            self.__Child2 = value
+
+        Child2 = property(_get_Child2, _set_Child2)
+
+        def as_dict(self):
+            d = dict()
+            if self.__IntVal is not None:
+                d["IntVal"] = (
+                    self.__IntVal.as_dict()
+                    if hasattr(self.__IntVal, "as_dict")
+                    else self.__IntVal
+                )
+            if self.__Child2 is not None:
+                d["Child2"] = (
+                    self.__Child2.as_dict()
+                    if hasattr(self.__Child2, "as_dict")
+                    else self.__Child2
+                )
+            return d
+
+        def __repr__(self):
+            return "<Class _Child1. IntVal: {}, Child2: {}>".format(
+                self.__IntVal, self.__Child2
+            )
+
+    _types_map = {"Child1": {"type": _Child1, "subtype": None}}
+    _formats_map = {}
+
+    def __init__(self, Child1=None):
+        pass
+        self.__Child1 = Child1
+
+    def _get_Child1(self):
+        return self.__Child1
+
+    def _set_Child1(self, value):
+        if not isinstance(value, Abcd._Child1):
+            raise TypeError("Child1 must be _Child1")
+
+        self.__Child1 = value
+
+    Child1 = property(_get_Child1, _set_Child1)
+
+    def as_dict(self):
+        d = dict()
+        if self.__Child1 is not None:
+            d["Child1"] = (
+                self.__Child1.as_dict()
+                if hasattr(self.__Child1, "as_dict")
+                else self.__Child1
+            )
+        return d
+
+    def __repr__(self):
+        return "<Class Abcd. Child1: {}>".format(self.__Child1)

--- a/test/valid/test_root_nested_objects.py
+++ b/test/valid/test_root_nested_objects.py
@@ -40,8 +40,32 @@ class Abcd:
 
             ListVal = property(_get_ListVal, _set_ListVal)
 
+            @staticmethod
+            def from_dict(d):
+                v = {}
+                if "IntVal" in d:
+                    if not isinstance(d["IntVal"], int):
+                        raise TypeError("IntVal must be int")
+
+                    v["IntVal"] = (
+                        int.from_dict(d["IntVal"])
+                        if hasattr(int, "from_dict")
+                        else d["IntVal"]
+                    )
+                if "ListVal" in d:
+                    if not isinstance(d["ListVal"], list):
+                        raise TypeError("ListVal must be list")
+                    if not all(isinstance(i, str) for i in d["ListVal"]):
+                        raise TypeError("ListVal list values must be str")
+
+                    v["ListVal"] = [
+                        str.from_dict(p) if hasattr(str, "from_dict") else p
+                        for p in d["ListVal"]
+                    ]
+                return Abcd._Child1._Child2(**v)
+
             def as_dict(self):
-                d = dict()
+                d = {}
                 if self.__IntVal is not None:
                     d["IntVal"] = (
                         self.__IntVal.as_dict()
@@ -87,14 +111,37 @@ class Abcd:
 
         def _set_Child2(self, value):
             if not isinstance(value, Abcd._Child1._Child2):
-                raise TypeError("Child2 must be _Child2")
+                raise TypeError("Child2 must be Abcd._Child1._Child2")
 
             self.__Child2 = value
 
         Child2 = property(_get_Child2, _set_Child2)
 
+        @staticmethod
+        def from_dict(d):
+            v = {}
+            if "IntVal" in d:
+                if not isinstance(d["IntVal"], int):
+                    raise TypeError("IntVal must be int")
+
+                v["IntVal"] = (
+                    int.from_dict(d["IntVal"])
+                    if hasattr(int, "from_dict")
+                    else d["IntVal"]
+                )
+            if "Child2" in d:
+                if not isinstance(d["Child2"], Abcd._Child1._Child2):
+                    raise TypeError("Child2 must be Abcd._Child1._Child2")
+
+                v["Child2"] = (
+                    Abcd._Child1._Child2.from_dict(d["Child2"])
+                    if hasattr(Abcd._Child1._Child2, "from_dict")
+                    else d["Child2"]
+                )
+            return Abcd._Child1(**v)
+
         def as_dict(self):
-            d = dict()
+            d = {}
             if self.__IntVal is not None:
                 d["IntVal"] = (
                     self.__IntVal.as_dict()
@@ -126,14 +173,28 @@ class Abcd:
 
     def _set_Child1(self, value):
         if not isinstance(value, Abcd._Child1):
-            raise TypeError("Child1 must be _Child1")
+            raise TypeError("Child1 must be Abcd._Child1")
 
         self.__Child1 = value
 
     Child1 = property(_get_Child1, _set_Child1)
 
+    @staticmethod
+    def from_dict(d):
+        v = {}
+        if "Child1" in d:
+            if not isinstance(d["Child1"], Abcd._Child1):
+                raise TypeError("Child1 must be Abcd._Child1")
+
+            v["Child1"] = (
+                Abcd._Child1.from_dict(d["Child1"])
+                if hasattr(Abcd._Child1, "from_dict")
+                else d["Child1"]
+            )
+        return Abcd(**v)
+
     def as_dict(self):
-        d = dict()
+        d = {}
         if self.__Child1 is not None:
             d["Child1"] = (
                 self.__Child1.as_dict()

--- a/test/valid/test_root_string_enum.py
+++ b/test/valid/test_root_string_enum.py
@@ -9,6 +9,10 @@ class Abcd(enum.Enum):
     B = "B"
     C = "C"
 
+    @staticmethod
+    def from_dict(d):
+        return Abcd(d)
+
     def as_dict(self):
         return self.value
 

--- a/test/valid/test_root_string_enum.py
+++ b/test/valid/test_root_string_enum.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env/python
+
+import enum
+
+
+class Abcd(enum.Enum):
+
+    A = "A"
+    B = "B"
+    C = "C"
+
+    def as_dict(self):
+        return self.value
+
+    def __repr__(self):
+        return "<Enum Abcd. {}: {}>".format(self.name, self.value)


### PR DESCRIPTION
# Since I haven't seen the author commit or reply to anything here since before October 2018, I have forked the project with several added features and future support. See https://github.com/MikeDombo/JSONSchema2PoPo2.

This commit brings support for string enums such as 
```
"A": {
      "type": "string",
      "enum": ["X", "Z"]
    }
```

which turns into 
```
class A(enum.Enum):

    X = "X"
    Z = "Z"

    _types_map = {}
    _formats_map = {}

    def as_dict(self):
        return self.value

    def __repr__(self):
        return "<Enum A. {}: {}>".format(self.name, self.value)
```

Which works as you would expect a proper Python enum to work. So I can say `A.X` and that will be equal to `X`.